### PR TITLE
feat: implement profile store for enhanced storage configuration management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +106,18 @@ name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
 
 [[package]]
 name = "assert_cmd"
@@ -198,10 +220,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "block-buffer"
@@ -270,6 +307,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +342,17 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -407,6 +479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -426,6 +499,27 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -453,6 +547,12 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -686,6 +786,12 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "hdfs-sys"
@@ -1001,6 +1107,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.0",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1184,16 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libredox"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+dependencies = [
+ "bitflags",
+ "libc",
+]
 
 [[package]]
 name = "libtest-mimic"
@@ -1191,6 +1326,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "opendal"
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,13 +1361,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
 dependencies = [
  "dlv-list",
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1259,6 +1406,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,6 +1443,17 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -1481,6 +1650,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -1694,6 +1874,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1701,18 +1890,28 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.227"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "80ece43fc6fbed4eb5392ab50c07334d3e577cbf40997ee896fe7af40bba4245"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.227"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a576275b607a2c86ea29e410193df32bc680303c82f31e275bbfcafe8b33be5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.227"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "51e694923b8824cf0e9b382adf0f60d4e05f348f357b38833a3fa5ed7c2ede04"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1729,6 +1928,15 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5417783452c2be558477e104686f7de5dae53dba813c28435e0e70f82d9b04ee"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -1855,19 +2063,25 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 name = "storify"
 version = "0.1.1"
 dependencies = [
+ "argon2",
  "assert_cmd",
  "async-recursion",
+ "base64",
+ "chacha20poly1305",
  "clap",
+ "directories",
  "futures",
  "libtest-mimic",
  "log",
  "opendal",
  "predicates",
  "rand 0.9.2",
+ "secrecy",
  "serde",
  "serde_json",
  "snafu",
  "tokio",
+ "toml",
  "tracing-subscriber",
  "uuid",
 ]
@@ -2039,6 +2253,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00e5e5d9bf2475ac9d4f0d9edab68cc573dc2fd644b0dba36b0c30a92dd9eaa0"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d163a63c116ce562a22cda521fcc4d79152e7aba014456fb5eb442f6d6a10109"
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2131,6 +2384,16 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -2570,6 +2833,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,13 @@ snafu = "0.8.9"
 tokio = { version = "1.47.1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.143"
+toml = "0.9.7"
+directories = "6.0.0"
+chacha20poly1305 = "0.10.1"
+rand = { version = "0.9.2", features = ["std"] }
+base64 = "0.22.1"
+argon2 = "0.5"
+secrecy = "0.10"
 
 [dev-dependencies]
 assert_cmd = "2.0.17"

--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ COS_SECRET_KEY *(preferred; maps to STORAGE_ACCESS_KEY_SECRET)*
 STORAGE_ROOT_PATH=./storage
 ```
 
+### Environment key priority
+
+Storify resolves environment variables in a deterministic order so existing setups continue to work:
+
+- **OSS**: `STORAGE_*` overrides `OSS_*`.
+- **S3**: `STORAGE_*` overrides `AWS_*`, which in turn overrides `MINIO_*` (handy when migrating MinIO configs without renaming keys).
+- **MinIO alias** (`STORAGE_PROVIDER=minio`): `STORAGE_*` overrides `MINIO_*`.
+- **COS**: `STORAGE_*` overrides `COS_*`.
+- **HDFS**: `HDFS_NAME_NODE` is required; `HDFS_ROOT_PATH` remains optional.
+
+When required fields are missing, Storify returns actionable errors that end with ``hint: run `storify config` or supply --profile``.
+
 ## Usage
 
 ```bash

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,8 +1,10 @@
 pub mod loader;
+pub mod profile_store;
 pub mod provider;
 pub mod spec;
 pub mod storage_config;
 
+pub use profile_store::{ProfileStore, StoredProfile};
 pub use provider::StorageProvider;
 pub use spec::prepare_storage_config;
 pub use storage_config::StorageConfig;

--- a/src/config/profile_store.rs
+++ b/src/config/profile_store.rs
@@ -1,0 +1,674 @@
+use crate::config::{StorageProvider, storage_config::StorageConfig};
+use crate::error::{Error, Result};
+use argon2::{Algorithm, Argon2, Params as Argon2Params, Version};
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use chacha20poly1305::aead::{Aead, KeyInit};
+use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
+use directories::ProjectDirs;
+use rand::{RngCore, rng};
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+#[cfg(not(unix))]
+use std::sync::Once;
+
+const VERSION: u8 = 1;
+const FILE_NAME: &str = "profiles.toml";
+const BACKUP_SUFFIX: &str = "bak";
+const KEY_LENGTH: usize = 32;
+const ARGON2_ALGORITHM: &str = "ARGON2ID";
+const DEFAULT_ARGON2_MEMORY_KIB: u32 = 64 * 1024;
+const DEFAULT_ARGON2_ITERATIONS: u32 = 3;
+const DEFAULT_ARGON2_LANES: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StoredProfile {
+    pub provider: String,
+    pub bucket: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access_key_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access_key_secret: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name_node: Option<String>,
+    #[serde(default)]
+    pub anonymous: bool,
+}
+
+impl StoredProfile {
+    pub fn from_config(config: &StorageConfig) -> Self {
+        Self {
+            provider: config.provider.as_str().to_string(),
+            bucket: config.bucket.clone(),
+            access_key_id: config.access_key_id.clone(),
+            access_key_secret: config.access_key_secret.clone(),
+            endpoint: config.endpoint.clone(),
+            region: config.region.clone(),
+            root_path: config.root_path.clone(),
+            name_node: config.name_node.clone(),
+            anonymous: config.anonymous,
+        }
+    }
+
+    pub fn into_config(self) -> Result<StorageConfig> {
+        let provider = StorageProvider::from_str(&self.provider)?;
+        let mut config = StorageConfig {
+            provider,
+            bucket: self.bucket,
+            access_key_id: self.access_key_id,
+            access_key_secret: self.access_key_secret,
+            endpoint: self.endpoint,
+            region: self.region,
+            root_path: self.root_path,
+            name_node: self.name_node,
+            anonymous: self.anonymous,
+        };
+        crate::config::prepare_storage_config(&mut config)?;
+        Ok(config)
+    }
+
+    pub fn redacted(&self) -> Self {
+        let mut clone = self.clone();
+        if clone.access_key_id.is_some() {
+            clone.access_key_id = Some("****".to_string());
+        }
+        if clone.access_key_secret.is_some() {
+            clone.access_key_secret = Some("****".to_string());
+        }
+        clone
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ProfileStore {
+    path: PathBuf,
+    encryption: Encryption,
+}
+
+#[derive(Debug, Clone)]
+enum Encryption {
+    Plaintext,
+    MasterPassword(MasterPasswordEncryption),
+}
+
+#[derive(Debug, Clone)]
+struct MasterPasswordEncryption {
+    password: SecretString,
+}
+
+#[derive(Debug, Clone)]
+struct KdfParams {
+    memory_kib: u32,
+    iterations: u32,
+    lanes: u32,
+}
+
+impl KdfParams {
+    fn default_argon2() -> Self {
+        Self {
+            memory_kib: DEFAULT_ARGON2_MEMORY_KIB,
+            iterations: DEFAULT_ARGON2_ITERATIONS,
+            lanes: DEFAULT_ARGON2_LANES,
+        }
+    }
+
+    fn to_info(&self) -> KdfInfo {
+        KdfInfo {
+            algorithm: ARGON2_ALGORITHM.to_string(),
+            memory_kib: self.memory_kib,
+            iterations: self.iterations,
+            lanes: self.lanes,
+        }
+    }
+
+    fn parse(info: KdfInfo) -> Result<Self> {
+        if info.algorithm.eq_ignore_ascii_case(ARGON2_ALGORITHM) {
+            Ok(Self {
+                memory_kib: info.memory_kib,
+                iterations: info.iterations,
+                lanes: info.lanes,
+            })
+        } else {
+            Err(Error::ProfileDecryption {
+                message: format!("unsupported kdf: {}", info.algorithm),
+            })
+        }
+    }
+}
+
+#[derive(Default)]
+struct ProfilesState {
+    default_profile: Option<String>,
+    profiles: BTreeMap<String, StoredProfile>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PlainProfilesFile {
+    version: u8,
+    default_profile: Option<String>,
+    profiles: BTreeMap<String, StoredProfile>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct EncryptedProfilesFile {
+    version: u8,
+    encryption: EncryptedPayload,
+}
+
+#[derive(Serialize, Deserialize)]
+struct EncryptedPayload {
+    algorithm: String,
+    kdf: KdfInfo,
+    salt: String,
+    nonce: String,
+    data: String,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct KdfInfo {
+    algorithm: String,
+    memory_kib: u32,
+    iterations: u32,
+    lanes: u32,
+}
+
+impl ProfileStore {
+    pub fn open_default(password: Option<String>) -> Result<Self> {
+        let path = default_profiles_path()?;
+        Ok(Self::with_path(path, password))
+    }
+
+    pub fn with_path(path: PathBuf, password: Option<String>) -> Self {
+        Self {
+            path,
+            encryption: Encryption::from_password(password),
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn load(&self, name: &str) -> Result<Option<StoredProfile>> {
+        let state = self.read_state()?;
+        Ok(state.profiles.get(name).cloned())
+    }
+
+    pub fn save(&self, name: &str, profile: StoredProfile, set_default: bool) -> Result<()> {
+        let mut state = self.read_state()?;
+        state.profiles.insert(name.to_string(), profile);
+        if set_default {
+            state.default_profile = Some(name.to_string());
+        }
+        self.write_state(&state)
+    }
+
+    pub fn remove(&self, name: &str) -> Result<()> {
+        let mut state = self.read_state()?;
+        state.profiles.remove(name);
+        if state
+            .default_profile
+            .as_ref()
+            .map(|default| default == name)
+            .unwrap_or(false)
+        {
+            state.default_profile = None;
+        }
+        self.write_state(&state)
+    }
+
+    pub fn list_profiles(&self) -> Result<Vec<String>> {
+        let state = self.read_state()?;
+        Ok(state.profiles.keys().cloned().collect())
+    }
+
+    pub fn list_profiles_redacted(&self) -> Result<Vec<(String, StoredProfile)>> {
+        let state = self.read_state()?;
+        Ok(state
+            .profiles
+            .iter()
+            .map(|(name, p)| (name.clone(), p.redacted()))
+            .collect())
+    }
+
+    pub fn default_profile(&self) -> Result<Option<String>> {
+        let state = self.read_state()?;
+        Ok(state.default_profile)
+    }
+
+    pub fn set_default_profile(&self, profile: Option<&str>) -> Result<()> {
+        let mut state = self.read_state()?;
+        state.default_profile = profile.map(|p| p.to_string());
+        self.write_state(&state)
+    }
+
+    fn read_state(&self) -> Result<ProfilesState> {
+        if !self.path.exists() {
+            return Ok(ProfilesState::default());
+        }
+        let bytes = fs::read(&self.path).map_err(|source| Error::ProfileStoreIo {
+            path: self.path.clone(),
+            source,
+        })?;
+        let content = String::from_utf8(bytes).map_err(|err| Error::ProfileStoreUtf8 {
+            path: self.path.clone(),
+            source: err,
+        })?;
+
+        if content.trim().is_empty() {
+            return Ok(ProfilesState::default());
+        }
+
+        if let Some(state) = self.try_read_encrypted(&content)? {
+            return Ok(state);
+        }
+
+        let file = self.decode_plain_profiles(&content)?;
+        Ok(ProfilesState {
+            default_profile: file.default_profile,
+            profiles: file.profiles,
+        })
+    }
+
+    fn write_state(&self, state: &ProfilesState) -> Result<()> {
+        let plaintext = PlainProfilesFile {
+            version: VERSION,
+            default_profile: state.default_profile.clone(),
+            profiles: state.profiles.clone(),
+        };
+
+        ensure_dir(self.path.parent())?;
+        let serialized = match &self.encryption {
+            Encryption::Plaintext => toml::to_string_pretty(&plaintext).map_err(|source| {
+                Error::ProfileStoreSerialize {
+                    path: self.path.clone(),
+                    source,
+                }
+            })?,
+            Encryption::MasterPassword(strategy) => {
+                let plain =
+                    toml::to_string(&plaintext).map_err(|source| Error::ProfileStoreSerialize {
+                        path: self.path.clone(),
+                        source,
+                    })?;
+                let encrypted = strategy.encrypt(plain.as_bytes())?;
+                let file = EncryptedProfilesFile {
+                    version: VERSION,
+                    encryption: encrypted,
+                };
+                toml::to_string_pretty(&file).map_err(|source| Error::ProfileStoreSerialize {
+                    path: self.path.clone(),
+                    source,
+                })?
+            }
+        };
+
+        if self.path.exists() {
+            let backup = self.path.with_extension(BACKUP_SUFFIX);
+            fs::copy(&self.path, &backup).map_err(|source| Error::ProfileStoreIo {
+                path: backup.clone(),
+                source,
+            })?;
+            set_secure_permissions(&backup)?;
+        }
+
+        let tmp_path = self.path.with_extension("tmp");
+        let write_result = (|| -> Result<()> {
+            let mut tmp_file = OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(&tmp_path)
+                .map_err(|source| Error::ProfileStoreIo {
+                    path: tmp_path.clone(),
+                    source,
+                })?;
+            tmp_file
+                .write_all(serialized.as_bytes())
+                .map_err(|source| Error::ProfileStoreIo {
+                    path: tmp_path.clone(),
+                    source,
+                })?;
+            tmp_file
+                .sync_all()
+                .map_err(|source| Error::ProfileStoreIo {
+                    path: tmp_path.clone(),
+                    source,
+                })?;
+            Ok(())
+        })();
+
+        if let Err(err) = write_result {
+            fs::remove_file(&tmp_path).ok();
+            return Err(err);
+        }
+
+        set_secure_permissions(&tmp_path)?;
+        fs::rename(&tmp_path, &self.path).map_err(|source| Error::ProfileStoreIo {
+            path: self.path.clone(),
+            source,
+        })?;
+        set_secure_permissions(&self.path)?;
+        Ok(())
+    }
+
+    fn try_read_encrypted(&self, content: &str) -> Result<Option<ProfilesState>> {
+        if let Ok(encrypted) = toml::from_str::<EncryptedProfilesFile>(content) {
+            return self.decrypt_state(encrypted).map(Some);
+        }
+        Ok(None)
+    }
+
+    fn decrypt_state(&self, encrypted: EncryptedProfilesFile) -> Result<ProfilesState> {
+        if encrypted.encryption.algorithm != MasterPasswordEncryption::ALGORITHM {
+            return Err(Error::ProfileDecryption {
+                message: "Unsupported encryption algorithm".to_string(),
+            });
+        }
+        let plain = self.encryption.decrypt(&encrypted, &self.path)?;
+        let file = self.decode_plain_profiles(&plain)?;
+        Ok(ProfilesState {
+            default_profile: file.default_profile,
+            profiles: file.profiles,
+        })
+    }
+
+    fn decode_plain_profiles(&self, plain: &str) -> Result<PlainProfilesFile> {
+        toml::from_str::<PlainProfilesFile>(plain)
+            .map_err(|source| Error::ProfileStoreParse {
+                path: self.path.clone(),
+                source,
+            })
+            .and_then(|file| {
+                ensure_version(file.version)?;
+                Ok(file)
+            })
+    }
+}
+
+impl Encryption {
+    fn from_password(password: Option<String>) -> Self {
+        match password {
+            Some(pwd) if !pwd.is_empty() => Encryption::MasterPassword(MasterPasswordEncryption {
+                password: SecretString::new(pwd.into_boxed_str()),
+            }),
+            _ => Encryption::Plaintext,
+        }
+    }
+
+    fn decrypt(&self, file: &EncryptedProfilesFile, path: &Path) -> Result<String> {
+        match self {
+            Encryption::MasterPassword(master) => master.decrypt(&file.encryption, path),
+            Encryption::Plaintext => Err(Error::ProfileDecryption {
+                message: "profiles are encrypted, provide a master password".to_string(),
+            }),
+        }
+    }
+}
+
+impl MasterPasswordEncryption {
+    const ALGORITHM: &'static str = "CHACHA20POLY1305";
+
+    fn encrypt(&self, data: &[u8]) -> Result<EncryptedPayload> {
+        let mut rng = rng();
+        let mut salt = [0u8; 16];
+        rng.fill_bytes(&mut salt);
+        let params = KdfParams::default_argon2();
+        let key = self.derive_key(&params, &salt)?;
+
+        let mut nonce_bytes = [0u8; 12];
+        rng.fill_bytes(&mut nonce_bytes);
+        let cipher = ChaCha20Poly1305::new(&key);
+        let nonce = Nonce::from_slice(&nonce_bytes);
+        let ciphertext = cipher
+            .encrypt(nonce, data)
+            .map_err(|_| Error::ProfileEncryption {
+                message: "encryption failed".to_string(),
+            })?;
+
+        Ok(EncryptedPayload {
+            algorithm: Self::ALGORITHM.to_string(),
+            kdf: params.to_info(),
+            salt: BASE64.encode(salt),
+            nonce: BASE64.encode(nonce_bytes),
+            data: BASE64.encode(ciphertext),
+        })
+    }
+
+    fn decrypt(&self, payload: &EncryptedPayload, path: &Path) -> Result<String> {
+        if payload.algorithm != Self::ALGORITHM {
+            return Err(Error::ProfileDecryption {
+                message: "unsupported encryption algorithm".to_string(),
+            });
+        }
+        let params = KdfParams::parse(payload.kdf.clone())?;
+        let salt =
+            BASE64
+                .decode(payload.salt.as_bytes())
+                .map_err(|_| Error::ProfileDecryption {
+                    message: "invalid salt".to_string(),
+                })?;
+        let nonce_bytes =
+            BASE64
+                .decode(payload.nonce.as_bytes())
+                .map_err(|_| Error::ProfileDecryption {
+                    message: "invalid nonce".to_string(),
+                })?;
+        let ciphertext =
+            BASE64
+                .decode(payload.data.as_bytes())
+                .map_err(|_| Error::ProfileDecryption {
+                    message: "invalid ciphertext".to_string(),
+                })?;
+        let key = self.derive_key(&params, &salt)?;
+        let cipher = ChaCha20Poly1305::new(&key);
+        let nonce = Nonce::from_slice(&nonce_bytes);
+        let plaintext =
+            cipher
+                .decrypt(nonce, ciphertext.as_ref())
+                .map_err(|_| Error::ProfileDecryption {
+                    message: "unable to decrypt profiles".to_string(),
+                })?;
+        String::from_utf8(plaintext).map_err(|err| Error::ProfileStoreUtf8 {
+            path: path.to_path_buf(),
+            source: err,
+        })
+    }
+
+    fn derive_key(&self, params: &KdfParams, salt: &[u8]) -> Result<Key> {
+        let argon_params = Argon2Params::new(
+            params.memory_kib,
+            params.iterations,
+            params.lanes,
+            Some(KEY_LENGTH),
+        )
+        .map_err(|_| Error::ProfileEncryption {
+            message: "invalid argon2 parameters".to_string(),
+        })?;
+        let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, argon_params);
+        let mut key_bytes = vec![0u8; KEY_LENGTH];
+        argon2
+            .hash_password_into(
+                self.password.expose_secret().as_bytes(),
+                salt,
+                &mut key_bytes,
+            )
+            .map_err(|_| Error::ProfileEncryption {
+                message: "argon2 derivation failed".to_string(),
+            })?;
+        let key = Key::from_slice(&key_bytes).to_owned();
+        key_bytes.fill(0);
+        Ok(key)
+    }
+}
+
+fn default_profiles_path() -> Result<PathBuf> {
+    if let Some(project_dirs) = ProjectDirs::from("dev", "Storify", "Storify") {
+        let mut path = project_dirs.config_dir().to_path_buf();
+        path.push(FILE_NAME);
+        Ok(path)
+    } else {
+        Err(Error::ProfileStoreUnavailable)
+    }
+}
+
+fn ensure_dir(path: Option<&Path>) -> Result<()> {
+    if let Some(dir) = path
+        && !dir.exists()
+    {
+        fs::create_dir_all(dir).map_err(|source| Error::ProfileStoreIo {
+            path: dir.to_path_buf(),
+            source,
+        })?;
+        set_secure_permissions(dir)?;
+    }
+    Ok(())
+}
+
+fn set_secure_permissions(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::fs::Permissions;
+        use std::os::unix::fs::PermissionsExt;
+        let mode = if path.is_dir() { 0o700 } else { 0o600 };
+        let permissions = Permissions::from_mode(mode);
+        fs::set_permissions(path, permissions).map_err(|source| Error::ProfileStoreIo {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    }
+    #[cfg(not(unix))]
+    {
+        use log::warn;
+        static PERMISSION_WARN_ONCE: Once = Once::new();
+        PERMISSION_WARN_ONCE.call_once(|| {
+            warn!(
+                "profile store permissions hardening is not available on this platform; check file ACLs manually"
+            );
+        });
+    }
+    Ok(())
+}
+
+fn ensure_version(version: u8) -> Result<()> {
+    if version == VERSION {
+        Ok(())
+    } else {
+        Err(Error::ProfileStoreVersion {
+            expected: VERSION,
+            found: version,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_store(name: &str, password: Option<&str>) -> ProfileStore {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "storify-profile-test-{}-{}.toml",
+            name,
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        ProfileStore::with_path(path, password.map(|s| s.to_string()))
+    }
+
+    fn sample_profile(provider: &str) -> StoredProfile {
+        StoredProfile {
+            provider: provider.to_string(),
+            bucket: "bucket".into(),
+            access_key_id: Some("id".into()),
+            access_key_secret: Some("secret".into()),
+            endpoint: Some("https://endpoint".into()),
+            region: Some("ap-southeast-1".into()),
+            root_path: None,
+            name_node: None,
+            anonymous: false,
+        }
+    }
+
+    fn cleanup(store: &ProfileStore) {
+        let path = store.path().to_path_buf();
+        fs::remove_file(&path).ok();
+        fs::remove_file(path.with_extension("bak")).ok();
+    }
+
+    #[test]
+    fn plain_round_trip() {
+        let store = temp_store("plain", None);
+        let profile = sample_profile("s3");
+        store
+            .save("dev", profile.clone(), true)
+            .expect("save plain profile");
+        let loaded = store
+            .load("dev")
+            .expect("load stored profile")
+            .expect("profile exists");
+        assert_eq!(loaded, profile);
+        assert_eq!(store.default_profile().unwrap(), Some("dev".into()));
+        cleanup(&store);
+    }
+
+    #[test]
+    fn encrypted_round_trip() {
+        let store = temp_store("enc", Some("password"));
+        let profile = sample_profile("oss");
+        store
+            .save("prod", profile.clone(), true)
+            .expect("save encrypted profile");
+        let loaded = store
+            .load("prod")
+            .expect("load stored profile")
+            .expect("profile exists");
+        assert_eq!(loaded, profile);
+        let content = fs::read_to_string(store.path()).expect("read encrypted file");
+        assert!(content.contains("kdf"));
+        assert!(!content.contains("default_profile"));
+        cleanup(&store);
+    }
+
+    #[test]
+    fn profile_listing_redacts_sensitive_values() {
+        let store = temp_store("list", None);
+        store
+            .save("dev", sample_profile("s3"), true)
+            .expect("save profile");
+        let list = store.list_profiles_redacted().unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].0, "dev");
+        assert_eq!(list[0].1.access_key_id.as_deref(), Some("****"));
+        cleanup(&store);
+    }
+
+    #[test]
+    fn encrypted_store_requires_password() {
+        let store = temp_store("enc-required", Some("secret"));
+        store
+            .save("prod", sample_profile("oss"), true)
+            .expect("save encrypted profile");
+        let path = store.path().to_path_buf();
+        let no_password = ProfileStore::with_path(path.clone(), None);
+        let err = no_password
+            .load("prod")
+            .expect_err("missing password should fail");
+        assert!(matches!(err, Error::ProfileDecryption { .. }));
+        cleanup(&store);
+    }
+}


### PR DESCRIPTION
## Refer to a related PR or issue link (optional)

part of #43 

## What's changed and what's your intention?


- Added `ProfileStore` for managing user profiles with support for encryption.
- Introduced methods for saving, loading, and listing profiles.
- Enhanced error handling for profile operations.
- Updated environment variable resolution to support profile hints.
- Added tests for profile management functionality.

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist

Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary tests.
- [x] This PR requires documentation updates.
