### PR TITLE
docs: refactor documentation layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Storify
 
-A unified command-line tool for managing object storage with HDFS-like interface.
+Storify is a fast, convenient CLI for cloud object storage—profile-driven configs (encrypted and easy to override), portable commands that behave the same everywhere, and high-throughput async transfers with live progress so switching providers and moving data stays smooth.
 
 ## Features
 
 - **Multi-cloud support**: OSS, S3, MinIO, COS, HDFS, and local filesystem
-- **HDFS-compatible commands**: Familiar interface for Hadoop users
 - **Profile management**: Encrypted storage for multiple configurations
 - **Unified configuration**: Single tool for all storage providers
 - **High performance**: Async I/O with progress reporting
@@ -23,7 +22,7 @@ cargo build --release
 
 The binary will be available at `target/release/storify`.
 
-### From Cargo (when published)
+### From Cargo
 
 ```bash
 cargo install storify
@@ -67,212 +66,30 @@ export STORAGE_ENDPOINT=your-endpoint
 export STORAGE_REGION=your-region
 ```
 
-### Provider-Specific Variables
-
-```bash
-# OSS
-OSS_BUCKET, OSS_ACCESS_KEY_ID, OSS_ACCESS_KEY_SECRET, OSS_ENDPOINT, OSS_REGION
-
-# AWS S3  
-AWS_S3_BUCKET, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION
-
-# MinIO
-MINIO_BUCKET, MINIO_ACCESS_KEY, MINIO_SECRET_KEY, MINIO_ENDPOINT, MINIO_DEFAULT_REGION
-
-# COS (Tencent Cloud)
-COS_BUCKET, COS_SECRET_ID, COS_SECRET_KEY
-
-# Filesystem
-STORAGE_ROOT_PATH=./storage
-
-# HDFS
-HDFS_NAME_NODE=hdfs://namenode:8020
-HDFS_ROOT_PATH=/user/data
-```
-
-**Variable Priority**: `STORAGE_*` overrides provider-specific variables (e.g., `STORAGE_BUCKET` overrides `OSS_BUCKET`).
-
-## Usage
-
-### Storage Operations
+## Common commands
 
 ```bash
 # List directory contents
 storify ls path/to/dir
-storify ls path/to/dir -L          # detailed format
-storify ls path/to/dir -R          # recursive
 
 # Download files/directories  
 storify get remote/path local/path
 
-# Upload files/directories
-storify put local/path remote/path
-storify put local/dir remote/dir -R # recursive
+# Upload directory recursively
+storify put -R local/dir remote/dir
 
 # Copy within storage
 storify cp source/path dest/path
-
-# Move/rename within storage
-storify mv source/path dest/path
-
-# Create directories
-storify mkdir path/to/dir
-storify mkdir -p path/to/nested/dir  # create parents
-
-# Display file contents
-storify cat path/to/file
-
-# Display beginning of file
-storify head path/to/file          # first 10 lines (default)
-storify head -n 20 path/to/file    # first 20 lines
-storify head -c 1024 path/to/file  # first 1024 bytes
-storify head -q file1 file2        # suppress headers
-
-# Display end of file
-storify tail path/to/file          # last 10 lines (default)
-storify tail -n 20 path/to/file    # last 20 lines
-storify tail -c 1024 path/to/file  # last 1024 bytes
-storify tail -v path/to/file       # always show header
-
-# Search for patterns
-storify grep "pattern" path/to/file       # basic search
-storify grep -i "pattern" path/to/file    # case-insensitive
-storify grep -n "pattern" path/to/file    # show line numbers
-storify grep -R "pattern" path/           # recursive
-
-# Diff two files (unified diff)
-storify diff left/file right/file          # unified diff with 3 lines context
-storify diff -U 1 left/file right/file     # set context lines
-storify diff -w left/file right/file       # ignore trailing whitespace
-storify diff --size-limit 1 -f left right  # size guard and force
-
-# Find objects by name/regex/type
-storify find path/ --name '**/*.log'     # glob on full path
-storify find path/ --regex '.*\\.(csv|parquet)$'  # regex on full path
-storify find path/ --type f                # filter by type: f|d|o
-
-# Show directory structure as a tree
-storify tree path/to/dir              # show full tree
-storify tree path/to/dir -d 1         # limit depth to 1
-storify tree path/to/dir --dirs-only  # show directories only
-
-# Show disk usage
-storify du path/to/dir
-storify du path/to/dir -s          # summary only
-
-# Delete files/directories
-storify rm path/to/file
-storify rm path/to/dir -R          # recursive
-storify rm path/to/dir -Rf         # recursive + force (no confirmation)
-
-# Show object metadata
-storify stat path/to/file          # human-readable
-storify stat path/to/file --json   # JSON output
-storify stat path/to/file --raw    # raw key=value format
-
-# Create files (touch)
-storify touch path/to/file                 # create if missing; no change if exists
-storify touch -t path/to/file              # truncate to 0 bytes if exists
-storify touch -c path/to/missing           # do not create; succeed silently
-storify touch -p path/to/nested/file       # create parents when applicable
-
-## Command Reference
-
-### Storage Commands
-
-| Command | Description | Options |
-|---------|-------------|---------|
-| `ls` | List directory contents | `-L` (detailed), `-R` (recursive) |
-| `get` | Download files from remote |
-| `put` | Upload files to remote | `-R` (recursive) |
-| `cp` | Copy files within storage |
-| `mv` | Move/rename files within storage | 
-| `mkdir` | Create directories | `-p` (create parents) |
-| `touch` | Create files |
-| `cat` | Display file contents |
-| `head` | Display beginning of file | `-n` (lines), `-c` (bytes), `-q` (quiet), `-v` (verbose) |
-| `tail` | Display end of file | `-n` (lines), `-c` (bytes), `-q` (quiet), `-v` (verbose) |
-| `grep` | Search for patterns in files | `-i` (case-insensitive), `-n` (line numbers) ,`-R` (recursive) |
-| `find` | Find objects by name/regex/type | `--name <GLOB>`, `--regex <RE>`, `--type <f|d|o>` |
-| `rm` | Delete files/directories | `-R` (recursive), `-f` (force) |
-| `tree` | View directory structure as a tree | `-d <DEPTH>`, `--dirs-only` |
-| `du` | Show disk usage | `-s` (summary) |
-| `stat` | Show object metadata | `--json`, `--raw` |
-| `diff` | Compare two files (unified diff) | `-U <N>` (context), `-w` (ignore-space), `--size-limit <MB>`, `-f` (force) |
-
-### Config Commands
-
-| Command | Description | Options |
-|---------|-------------|---------|
-| `config create` | Create/update profile | Provider-specific flags, `--anonymous`, `--make-default`, `--force` |
-| `config list` | List all profiles | `--show-secrets` |
-| `config show` | Show configuration | `--profile <NAME>`, `--default`, `--show-secrets` |
-| `config set` | Set/clear default profile | `<NAME>` or `--clear` |
-| `config delete` | Delete a profile | `<NAME>`, `--force` |
-
-## Supported Providers
-
-| Provider | Type | Anonymous Support |
-|----------|------|-------------------|
-| **OSS** | Alibaba Cloud Object Storage | ✅ Yes |
-| **S3** | Amazon S3 | ✅ Yes |
-| **MinIO** | Self-hosted S3-compatible | ✅ Yes |
-| **COS** | Tencent Cloud Object Storage | ❌ No |
-| **FS** | Local Filesystem | ✅ Yes (always) |
-| **HDFS** | Hadoop Distributed File System | ❌ No |
-| **Azblob** | Azure Cloud Object Storage | ❌ No |
-
-## Architecture
-
-Built on [OpenDAL](https://github.com/apache/opendal) for unified storage access.
-
-```
-┌─────────────────────────────────────┐
-│            Storify CLI              │
-├─────────────────────────────────────┤
-│       Profile Store (Encrypted)     │
-├─────────────────────────────────────┤
-│           Config Loader             │
-├─────────────────────────────────────┤
-│          Storage Client             │
-├─────────────────────────────────────┤
-│             OpenDAL                 │
-├─────────────────────────────────────┤
-│ OSS │ S3 │ COS │ HDFS │ FS │ Azblob │
-└─────────────────────────────────────┘
 ```
 
-## Security
+More commands: see [`docs/usage.md`](docs/usage.md).
 
-- **Encryption**: Profile store uses AES-256-GCM encryption
-- **File Permissions**: Unix systems set 0600 permissions on profile store
-- **Atomic Writes**: Configuration changes use atomic file operations
-- **Backup**: Automatic backup (`.bak`) before modifications
+## Documentation
 
-## Development
-
-### Prerequisites
-
-- Rust 1.80+ (specified in `rust-toolchain.toml`)
-- Cargo
-- Git
-
-### Building
-
-```bash
-# Debug build
-cargo build
-
-# Release build (optimized)
-cargo build --release
-
-# Run tests
-cargo test
-
-# Run with clippy
-cargo clippy --all-targets --workspace -- -D warnings
-```
-
+- Usage guide: [`docs/usage.md`](docs/usage.md)
+- Configuration and providers: [`docs/config-providers.md`](docs/config-providers.md)
+- Architecture and development: [`docs/dev-arch.md`](docs/dev-arch.md)
+- FAQ: [`docs/faq.md`](docs/faq.md)
 
 ## Contributing
 

--- a/docs/config-providers.md
+++ b/docs/config-providers.md
@@ -1,0 +1,37 @@
+# Configuration and Providers
+
+Storify supports two configuration styles: encrypted profiles and environment variables. Environment variables always win over stored profile values.
+
+## Profiles (recommended)
+- Create interactively: `storify config create myprofile`
+- Create with flags: `storify config create prod --provider oss --bucket my-bucket`
+- List profiles: `storify config list`
+- Set default: `storify config set myprofile`
+- Show config: `storify config show --profile myprofile`
+- Delete: `storify config delete myprofile`
+
+## Environment variables
+- Choose provider: `STORAGE_PROVIDER` (`oss`, `s3`, `minio`, `cos`, `fs`, `hdfs`, `azblob`)
+- Common variables:
+  - `STORAGE_BUCKET`
+  - `STORAGE_ACCESS_KEY_ID`
+  - `STORAGE_ACCESS_KEY_SECRET`
+  - Optional: `STORAGE_ENDPOINT`, `STORAGE_REGION`
+- Precedence: `STORAGE_*` overrides provider-specific variables (for example `STORAGE_BUCKET` overrides `OSS_BUCKET`).
+
+### Provider-specific variables
+- OSS: `OSS_BUCKET`, `OSS_ACCESS_KEY_ID`, `OSS_ACCESS_KEY_SECRET`, `OSS_ENDPOINT`, `OSS_REGION`
+- AWS S3: `AWS_S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`
+- MinIO: `MINIO_BUCKET`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, `MINIO_ENDPOINT`, `MINIO_DEFAULT_REGION`
+- COS: `COS_BUCKET`, `COS_SECRET_ID`, `COS_SECRET_KEY`
+- Filesystem: `STORAGE_ROOT_PATH=./storage`
+- HDFS: `HDFS_NAME_NODE`, `HDFS_ROOT_PATH`
+
+### Anonymous support
+- OSS, S3, MinIO, FS: Yes (supported)
+- COS, HDFS, Azblob: No (not supported)
+
+## Security
+- Profile store is encrypted with AES-256-GCM.
+- On Unix, profile store permissions are set to 0600.
+- Writes are atomic; a `.bak` backup is created before modifying the store.

--- a/docs/dev-arch.md
+++ b/docs/dev-arch.md
@@ -1,0 +1,44 @@
+# Architecture and Development
+
+Storify is built on [OpenDAL](https://github.com/apache/opendal) to provide a unified storage layer.
+
+```mermaid
+flowchart TB
+    cli[Storify CLI]
+    profiles["Profile Store<br/>(encrypted, per-user)"]
+    loader["Config Loader<br/>(profiles + env)"]
+    client["Storage Client<br/>(async I/O + commands)"]
+    opendal[OpenDAL abstraction]
+    subgraph providers[Storage Providers]
+        oss[OSS]
+        s3[S3]
+        minio[MinIO]
+        cos[COS]
+        hdfs[HDFS]
+        fs[FS]
+        azb[Azblob]
+    end
+
+    cli --> profiles --> loader --> client --> opendal
+    opendal --> oss
+    opendal --> s3
+    opendal --> minio
+    opendal --> cos
+    opendal --> hdfs
+    opendal --> fs
+    opendal --> azb
+```
+
+## Components
+- Profile Store: encrypted, ownership-locked store for multiple profiles.
+- Config Loader: merges profile values with environment variables (env overrides).
+- Storage Client: executes HDFS-like commands with progress-aware async I/O.
+- OpenDAL: provider abstraction covering OSS, S3, MinIO, COS, HDFS, FS, Azblob.
+
+## Development
+- Prerequisites: Rust 1.80+ (see `rust-toolchain.toml`), Cargo, Git.
+- Build (debug): `cargo build`
+- Build (release): `cargo build --release`
+- Tests: `cargo test`
+- Lints: `cargo clippy --all-targets --workspace -- -D warnings`
+- Contributions: see `CONTRIBUTING.md`

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,6 @@
+# FAQ (short)
+
+- **Auth fails even with env vars?** Double-check `STORAGE_*` overrides provider-specific vars; unset stale provider-specific env to avoid conflicts. For profiles, re-run `storify config show --show-secrets` to confirm values.
+- **Diff says size limit exceeded?** Use `storify diff --size-limit <MB> -f left right` to override the guard.
+- **Recursive semantics?** `-R` applies to `ls`, `put`, `rm`, and `find`; tree uses `-d` to bound depth.
+- **Windows path issues?** Prefer forward slashes in commands; if using PowerShell, quote globs (`'**/*.log'`).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,49 @@
+# Usage
+
+This page lists the common Storify CLI commands with short, copy-pastable examples.
+
+## Listing and navigation
+- List directory: `storify ls path/to/dir`
+- Detailed list: `storify ls -L path/to/dir`
+- Recursive list: `storify ls -R path/to/dir`
+- Tree view: `storify tree path/to/dir` or limit depth `storify tree -d 1 path/to/dir`
+
+## Transfer
+- Download: `storify get remote/path local/path`
+- Upload file: `storify put local/file remote/path`
+- Upload directory recursively: `storify put -R local/dir remote/dir`
+- Copy within storage: `storify cp source/path dest/path`
+- Move/rename: `storify mv source/path dest/path`
+
+## Create and delete
+- Create directory: `storify mkdir path/to/dir`
+- Create nested directories: `storify mkdir -p path/to/nested/dir`
+- Touch file (create if missing): `storify touch path/to/file`
+- Truncate file: `storify touch -t path/to/file`
+- Delete file: `storify rm path/to/file`
+- Delete recursively: `storify rm -R path/to/dir`
+- Delete recursively without confirmation: `storify rm -Rf path/to/dir`
+
+## View, search, and inspect
+- Show file contents: `storify cat path/to/file`
+- Head: `storify head path/to/file` (default 10 lines), or `storify head -n 20 path/to/file`
+- Tail: `storify tail path/to/file` (default 10 lines), or `storify tail -n 20 path/to/file`
+- Grep: `storify grep "pattern" path/to/file`, case-insensitive `-i`, show line numbers `-n`, recursive `-R`
+- Find by glob: `storify find path/ --name '**/*.log'`
+- Find by regex: `storify find path/ --regex '.*\\.(csv|parquet)$'`
+- Filter by type: `storify find path/ --type f` (f=file, d=dir, o=other)
+- Disk usage: `storify du path/to/dir` or summary only with `-s`
+- Stat metadata: `storify stat path/to/file` (human), `--json`, or `--raw`
+
+## Diff
+- Unified diff (3 lines context default): `storify diff left/file right/file`
+- Custom context: `storify diff -U 1 left/file right/file`
+- Ignore trailing whitespace: `storify diff -w left/file right/file`
+- Guard against large files and force: `storify diff --size-limit 1 -f left right`
+
+## Options cheat sheet
+- `-R`: recursive (works with `ls`, `put`, `rm`, `find`)
+- `-L`: long/detailed listing
+- `-d`: tree depth
+- `-f`: force (skip confirmations where applicable)
+- `--json` / `--raw`: structured output for `stat`


### PR DESCRIPTION
## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The README was trimmed into a concise landing page, and the detailed areas were moved into dedicated docs (`docs/usage.md`, `docs/config-providers.md`, `docs/dev-arch.md`, `docs/faq.md`). That gives contributors/users a clearer structure (usage examples, config guidance, merged dev+architecture page, FAQ) and keeps the root README fast to scan.

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist

Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary behavior tests.
- [x] This PR requires documentation updates.
