### PR TITLE
feat: implement temporary config cache with TTL support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 # This file contains example environment variables for configuring storify.
 # Copy this file to .env and fill in your actual values.
 #
-# Supported storage providers: oss, s3, minio, fs, hdfs
+# Supported storage providers: oss, s3, minio, cos, fs, hdfs, azblob
 # =============================================================================
 
 # =============================================================================
@@ -13,7 +13,7 @@
 # =============================================================================
 
 # Storage provider type (required)
-# Options: oss, s3, minio, fs, hdfs
+# Options: oss, s3, minio, cos, fs, hdfs, azblob
 # Default: oss
 STORAGE_PROVIDER=oss
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ storify config list
 storify config set myprofile
 ```
 
+### Temporary Config Cache (TTL)
+
+Use an encrypted, TTL-based temporary cache when you don't want to create a named profile:
+
+```bash
+# Set a temporary config (default TTL 24h)
+storify config create --temp --provider cos --bucket my-bucket
+
+# Clear temporary config
+storify config temp clear
+```
+
 ### Using Environment Variables
 
 Set your storage provider and credentials:

--- a/docs/config-providers.md
+++ b/docs/config-providers.md
@@ -1,6 +1,12 @@
 # Configuration and Providers
 
-Storify supports two configuration styles: encrypted profiles and environment variables. Environment variables always win over stored profile values.
+Storify supports encrypted profiles and environment variables. It also supports an encrypted temporary config cache with a TTL.
+
+## Resolution order (highest to lowest)
+- `--profile <name>` (explicit profile selection)
+- temporary config cache (if set and not expired)
+- environment variables (`STORAGE_PROVIDER` + provider-specific variables)
+- default profile (from profile store)
 
 ## Profiles (recommended)
 - Create interactively: `storify config create myprofile`
@@ -32,6 +38,6 @@ Storify supports two configuration styles: encrypted profiles and environment va
 - COS, HDFS, Azblob: No (not supported)
 
 ## Security
-- Profile store is encrypted with AES-256-GCM.
+- Profile store is encrypted with ChaCha20Poly1305 (field-level encryption).
 - On Unix, profile store permissions are set to 0600.
 - Writes are atomic; a `.bak` backup is created before modifying the store.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,3 +47,13 @@ This page lists the common Storify CLI commands with short, copy-pastable exampl
 - `-d`: tree depth
 - `-f`: force (skip confirmations where applicable)
 - `--json` / `--raw`: structured output for `stat`
+
+## Temporary config cache
+Use an encrypted, TTL-based temporary cache to switch providers quickly without creating a named profile:
+
+- Set temporary config (default TTL 24h): `storify config create --temp --provider cos --bucket my-bucket --access-key-id ... --access-key-secret ...`
+- Override TTL: `storify config create --temp --ttl 4h --provider s3 --bucket my-bucket`
+- Show current temp: `storify config temp show`
+- Clear temp: `storify config temp clear`
+
+`--profile <name>` always overrides the temporary cache for a single command.

--- a/src/cli/entry.rs
+++ b/src/cli/entry.rs
@@ -98,13 +98,16 @@ pub enum ConfigCommand {
     /// Show configuration information
     Show(ShowArgs),
     /// Create or update a profile in the profile store
-    Create(CreateArgs),
+    Create(Box<CreateArgs>),
     /// Mutate configuration settings (e.g. default profile)
     Set(SetArgs),
     /// List profiles in the profile store
     List(ListArgs),
     /// Delete a profile from the profile store
     Delete(DeleteArgs),
+    /// Manage temporary config cache (encrypted, TTL-based)
+    #[command(subcommand)]
+    Temp(TempCommand),
 }
 
 #[derive(ClapArgs, Debug, Clone)]
@@ -159,6 +162,36 @@ pub struct CreateArgs {
     /// Mark the profile as default after creation
     #[arg(long = "make-default")]
     pub make_default: bool,
+
+    /// Save as temporary config cache instead of a named profile
+    #[arg(long)]
+    pub temp: bool,
+
+    /// Time-to-live for temporary cache (e.g. 30m, 24h, 7d). Default: 24h
+    #[arg(long, default_value = "24h")]
+    pub ttl: String,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum TempCommand {
+    /// Show temporary config cache (if present and not expired)
+    Show(TempShowArgs),
+    /// Clear temporary config cache
+    Clear(TempClearArgs),
+}
+
+#[derive(ClapArgs, Debug, Clone)]
+pub struct TempShowArgs {
+    /// Show secrets in plaintext (access_key_id, access_key_secret). Default: redacted
+    #[arg(long)]
+    pub show_secrets: bool,
+}
+
+#[derive(ClapArgs, Debug, Clone)]
+pub struct TempClearArgs {
+    /// Skip confirmation prompt
+    #[arg(long)]
+    pub force: bool,
 }
 
 #[derive(ClapArgs, Debug, Clone)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -152,6 +152,7 @@ pub enum Error {
         "No configuration resolves. Available profiles: {profiles}. Hint: run `storify config` or supply --profile"
     ))]
     NoConfiguration { profiles: String },
+    // Reserved for future extension.
 }
 
 impl From<opendal::Error> for Error {

--- a/src/storage/operations/grep.rs
+++ b/src/storage/operations/grep.rs
@@ -205,7 +205,7 @@ impl OpenDalGreper {
         // Optimize ASCII fast-path for case-insensitive checks without allocations
         let matched = if opts.ignore_case {
             if line.is_ascii() && opts.needle.is_ascii() {
-                // opts.needle 已在外层按 ignore_case 预小写，这里仅对 haystack 做无分配按位比较
+                // opts.needle is pre-lowercased; compare haystack in-place without allocations.
                 Self::ascii_contains_case_insensitive(line.as_bytes(), opts.needle.as_bytes())
             } else {
                 line.to_lowercase().contains(opts.needle)


### PR DESCRIPTION
## Refer to a related PR or issue link (optional)

None

## What's changed and what's your intention?

This PR adds an encrypted, TTL-based temporary config cache to the existing profile store to make one-off provider switching easier without creating a named profile. It also defines and documents a consistent config resolution order: `--profile > temp cache (if not expired) > env vars > default profile`. New CLI entrypoints: `storify config create --temp --ttl 24h ... and storify config temp show|clear`.

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist

Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests.
- [x] This PR requires documentation updates.
